### PR TITLE
null defense

### DIFF
--- a/src/mask.ts
+++ b/src/mask.ts
@@ -28,7 +28,7 @@ export const mask = (value: string, patterns: string[]): string => {
       patternChar = computedPattern[i],
       inputChar = unmaskedValue[ii];
 
-    if (!token.test(inputChar)) break;
+    if (!token?.test(inputChar)) break;
     else if (/\W/.test(patternChar)) output += patternChar;
     else (output += token.transform(inputChar)), ii++;
   }


### PR DESCRIPTION
prevent runtime error if an unsupported token is encountered